### PR TITLE
Tail enhancements

### DIFF
--- a/Tail/config.py
+++ b/Tail/config.py
@@ -53,6 +53,9 @@ Tail = conf.registerPlugin('Tail')
 conf.registerGlobalValue(Tail, 'targets',
     Targets([], """Determines what targets will be messaged with lines from the
     files being tailed."""))
+conf.registerGlobalValue(Tail, 'prepend_filename',
+    registry.Boolean(True, """Determines whether the bot will prepend the filename
+    to the tail lines announced to the channel."""))
 conf.registerGlobalValue(Tail, 'bold',
     registry.Boolean(False, """Determines whether the bot will bold the filename
     in tail lines announced to the channel."""))

--- a/Tail/plugin.py
+++ b/Tail/plugin.py
@@ -142,8 +142,10 @@ class Tail(callbacks.Plugin):
                 irc.reply(format('%L', L))
             else:
                 irc.reply('I\'m not currently targeting anywhere.')
-        elif remove:
-            pass #XXX
+        else:
+            # XXX
+            irc.reply('Not implemented; use config plugins.Tail.targets instead')
+
     target = wrap(target, [getopts({'remove': ''}), any('something')])
 
 

--- a/Tail/plugin.py
+++ b/Tail/plugin.py
@@ -91,7 +91,10 @@ class Tail(callbacks.Plugin):
         if self.registryValue('bold'):
             filename = ircutils.bold(filename)
         notice = self.registryValue('notice')
-        payload = '%s: %s' % (filename, text)
+        if self.registryValue('prepend_filename'):
+            payload = '%s: %s' % (filename, text)
+        else:
+            payload = text
         for target in self.registryValue('targets'):
             irc.reply(payload, to=target, notice=notice, private=True)
 


### PR DESCRIPTION
I've implemented build failure notifications on IRC by having buildbot write to a file, which is watched by the Tail plugin.  I do not want every notification to be prefixed by a filename, so here's an option supybot.plugins.Tail.prepend_filename that you can set to False.

I've also added an error message to the 'target' command, because I kept trying to add targets with it and nothing would happen.  Sorry for mixing up two unrelated things in one pull request, but, hey, at least they're separate checkins.
